### PR TITLE
idle_in_transaction_session_time 지정하여 해결

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,6 +2,7 @@ name: infra-compose
 services:
   infra-db:
     image: postgres:15.4
+    command: -p 5432 -c idle_in_transaction_session_timeout=1805000
     environment:
       POSTGRES_USER: devteller
       POSTGRES_PASSWORD: devteller123!


### PR DESCRIPTION
### 원인
Hikari CP에서 커넥션이 해제되기 전에 먼저 DB 커넥션 자체가 끊겨서 발생하는 에러\
DB 작업을 위해 CP에서 유효한 커넥션을 찾아야 하는데, 가지고 있는 커넥션 모두 먼저 끊어졌기에 `connection has been closed` 에러 발생


### 해결방안
기본적으로 PostgreSQL의 `idle_in_transaction_session_timeout` 값은 활성화되지 않았기에, 이를 `maxLifeime` 보다 길에 지정하여 해결